### PR TITLE
Fix incorrect operator

### DIFF
--- a/src/Papercut.Network/ConnectionManager.cs
+++ b/src/Papercut.Network/ConnectionManager.cs
@@ -122,7 +122,7 @@ namespace Papercut.Network
                             foreach (int key in keys)
                             {
                                 // If they have been idle for too long, disconnect them
-                                if (DateTime.Now < _connections[key].LastActivity.AddMinutes(20))
+                                if (DateTime.Now > _connections[key].LastActivity.AddMinutes(20))
                                 {
                                     Logger.Information(
                                         "Session timeout, disconnecting {ConnectionId}",


### PR DESCRIPTION
The comparison should be `DateTime.Now > _connections[key].LastActivity.AddMinutes(20)` to close any connections that have been open longer than 20 minutes without any activity. This resolves #52.