### PR TITLE
Support for AUTH LOGIN and AUTH PLAIN

### DIFF
--- a/src/Papercut.Common/Extensions/GeneralExtensions.cs
+++ b/src/Papercut.Common/Extensions/GeneralExtensions.cs
@@ -40,6 +40,14 @@ namespace Papercut.Common.Extensions
             return byteEncoding.GetString(bytes);
         }
 
+        public static string ToBase64String(this string value, Encoding encoding = null)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+            
+            encoding = encoding ?? Encoding.UTF8;
+            return Convert.ToBase64String(encoding.GetBytes(value));
+        }
+
         /// <summary>
         ///     To FileSizeFormat... Thank you to "deepee1" on StackOverflow for this elegant solution:
         ///     http://stackoverflow.com/a/4975942

--- a/src/Papercut.Core/Domain/Network/Smtp/SmtpSession.cs
+++ b/src/Papercut.Core/Domain/Network/Smtp/SmtpSession.cs
@@ -70,6 +70,18 @@ namespace Papercut.Core.Domain.Network.Smtp
         /// </summary>
         public bool UseUtf8 { get; set; }
 
+        /// <summary>
+        ///     Gets or sets a value indicating whether this session requires authentication
+        ///     (to be determined by server setting)
+        /// </summary>
+        public bool RequireAuthentication { get; set; }
+                
+        /// <summary>
+        ///     Gets or sets a value determining the authenticated username
+        ///     (where null/empty means not authenticated)
+        /// </summary>
+        public string Username { get; set; }
+        
         #endregion
     }
 }

--- a/src/Papercut.Core/Domain/Network/Smtp/SmtpSession.cs
+++ b/src/Papercut.Core/Domain/Network/Smtp/SmtpSession.cs
@@ -74,7 +74,7 @@ namespace Papercut.Core.Domain.Network.Smtp
         ///     Gets or sets a value indicating whether this session requires authentication
         ///     (to be determined by server setting)
         /// </summary>
-        public bool RequireAuthentication { get; set; }
+        public bool RequiresAuthentication { get; set; }
                 
         /// <summary>
         ///     Gets or sets a value determining the authenticated username

--- a/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
@@ -1,0 +1,171 @@
+namespace Papercut.Network.SmtpCommands
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Papercut.Network.Protocols;
+
+    public class AuthSmtpCommand : BaseSmtpCommand
+    {
+        protected override IEnumerable<string> GetMatchCommands()
+        {
+            return new[] { "AUTH" };
+        }
+
+        protected override void Run(string command, params string[] args)
+        {
+            Task result = null;
+
+            Session.Username = null;
+
+            // TODO: If we were interested in TLS and/or STARTTLS, we would probably
+            // check here that we were in an encrypted context.  I imagine this to be
+            // something like:
+            //
+            // if (Connection.RequiresTls && !Connection.IsSecure)
+            // {
+            //     result = Connection.SendLine("538 Encryption required for AUTH");
+            // }
+            // else...
+
+            if ((args?.Length ?? 0) != 0)
+            {
+                try
+                {
+                    switch (args[0]?.ToUpperInvariant())
+                    {
+                        case "PLAIN":
+                            RunAuthPlain(args);
+                            break;
+
+                        case "LOGIN":
+                            RunAuthLogin();
+                            break;
+
+                        default:
+                            result = Connection.SendLine("504 Authentication method not implemented");
+                            break;
+                    }
+                }
+                finally
+                {
+                    if (result == null)
+                    {
+                        result = (!string.IsNullOrEmpty(Session?.Username)
+                               ? Connection.SendLine("235 Authentication successful")
+                               : Connection.SendLine("535 Authentication failed"));
+                    }
+                }
+            }
+            else result = Connection.SendLine("501 Authentication method not provided");
+
+            result.Wait();    
+        }
+
+        private void RunAuthPlain(string[] args)
+        {
+            // AUTH PLAIN accepts a base64-encoded authentication token comprised of
+            // an authorisation value, username and password, separated by the NUL char.
+            // The token is supplied either on the same line as the AUTH PLAIN command
+            // or on a separate line, after being prompted by a 334 message
+
+            string authToken = null;
+
+            if (args.Length != 1)
+            {
+                // auth token is sent on same line as AUTH PLAIN
+                authToken = args[1];
+            }
+            else
+            {
+                // auth token is to be sent separately on the next line
+                authToken = Connection.Client.ReadTextStream(reader => {
+                    Connection.SendLine("334").Wait();
+                    return reader.ReadLine();
+                });
+            }
+
+            if (!string.IsNullOrEmpty(authToken))
+            {
+                // decode the token as Base64, then split on \0 (nul);         
+                var decodedToken = DecodeString(authToken)?.Split('\0');
+
+                // [0] is the authorisation name (a SASL thing we probably don't need)
+                // [1] is the username; [2] is the password
+                if ((decodedToken?.Length ?? 0) == 3)
+                {
+                    Authenticate(decodedToken[1], decodedToken[2]);
+                }
+            }
+        }
+
+        private void RunAuthLogin()
+        {
+            // AUTH LOGIN prompts for two base64-encoded strings -- the username
+            // and password -- by sending two consecutive 334 messages.  As a foible,
+            // the two prompts are also base64-encoded.  We pre-encode these for some
+            // tiny micro-optimisation
+
+            const string usernamePrompt = "334 VXNlcm5hbWU6",   // Username:
+                         passwordPrompt = "334 UGFzc3dvcmQ6";   // Password:
+
+            var authToken = Connection.Client.ReadTextStream(reader => {
+                var lines = new string[2];
+
+                Connection.SendLine(usernamePrompt).Wait();
+                lines[0] = reader.ReadLine();
+
+                Connection.SendLine(passwordPrompt).Wait();
+                lines[1] = reader.ReadLine();
+
+                return lines;
+            });
+
+            if ((authToken?.Length ?? 0) == 2)
+            {
+                authToken[0] = DecodeString(authToken[0]);
+                authToken[1] = DecodeString(authToken[1]);
+                Authenticate(authToken[0], authToken[1]);
+            }
+        }
+
+        private string DecodeString(string base64String)
+        {
+            return (base64String == null)
+                 ? default(string)
+                 : (Connection.Encoding ?? Encoding.UTF8)
+                    .GetString(Convert.FromBase64String(base64String));
+        }
+
+        private void Authenticate(string username, string password)
+        {
+            // TODO: Here is where we'd do real authentication, if we needed the security.  
+            // A starting point might be to maintain a username/password dictionary in the
+            // server settings and compare to that; later implementations might perform an 
+            // LDAP bind against a configured domain controller, etc.
+
+            // NOTE: If we were serious about security, we should probably implement a
+            // a method to read a SecureString directly from the network stream without
+            // ever storing in an intermediary string, but this would require temporarily
+            // wrapping the network stream in a CryptoStream with FromBase64Transform, 
+            // reading each Char directly and inserting into the SecureString, which might
+            // be better served by a ReadBase64TextStream method in ConnectionExtensions
+
+            // For our, non-secure purposes, we just make sure we have a username and a
+            // password, and that the password is not null -- we are only testing that the
+            // upstream SmtpClient implementation correctly passes something (i.e. that
+            // a developer implementing SmtpClient to send has remembered to configure
+            // SMTP authentication options
+
+            // In any case, if authentication is successful, set the Session.Username to 
+            // the authenticated username, so the other commands know we're authenticated
+
+            if (!string.IsNullOrWhiteSpace(username) &&
+                password != null)
+            {
+                Session.Username = username;
+                Connection.Logger?.Information("Authenticated as '{0}'", Session.Username);
+            }
+        }
+    }
+}

--- a/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
@@ -7,6 +7,8 @@ namespace Papercut.Network.SmtpCommands
 
     public class AuthSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "AUTH" };

--- a/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/AuthSmtpCommand.cs
@@ -3,7 +3,8 @@ namespace Papercut.Network.SmtpCommands
     using System;
     using System.Collections.Generic;
 
-    using Papercut.Network.Protocols;
+    using Papercut.Common.Extensions;
+    using Papercut.Network.Protocols;    
 
     public class AuthSmtpCommand : BaseSmtpCommand
     {
@@ -105,19 +106,15 @@ namespace Papercut.Network.SmtpCommands
         {
             // AUTH LOGIN prompts for two base64-encoded strings -- the username
             // and password -- by sending two consecutive 334 messages.  As a foible,
-            // the two prompts are also base64-encoded.  We pre-encode these for some
-            // tiny micro-optimisation
-
-            const string usernamePrompt = "334 VXNlcm5hbWU6",   // Username:
-                         passwordPrompt = "334 UGFzc3dvcmQ6";   // Password:
+            // the two prompts are also base64-encoded.
 
             var authToken = Connection.Client.ReadTextStream(reader => {
                 var lines = new string[2];
 
-                Connection.SendLine(usernamePrompt).Wait();
+                Connection.SendLine($"334 {"Username:".ToBase64String()}").Wait();
                 lines[0] = reader.ReadLine();
 
-                Connection.SendLine(passwordPrompt).Wait();
+                Connection.SendLine($"334 {"Password:".ToBase64String()}").Wait();
                 lines[1] = reader.ReadLine();
 
                 return lines;

--- a/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
@@ -24,6 +24,7 @@ namespace Papercut.Network.SmtpCommands
     using Papercut.Common.Extensions;
     using Papercut.Core.Domain.Network;
     using Papercut.Core.Domain.Network.Smtp;
+    using Papercut.Network.Protocols;
 
     public abstract class BaseSmtpCommand : ISmtpCommand
     {

--- a/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
@@ -32,6 +32,8 @@ namespace Papercut.Network.SmtpCommands
         protected IConnection Connection => this.Context.Connection;
 
         public ISmtpContext Context { protected get; set; }
+        
+        protected virtual bool RequiresAuthentication { get { return true; } }
 
         public virtual SmtpCommandResult Execute(ISmtpContext context, string request)
         {

--- a/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/BaseSmtpCommand.cs
@@ -44,7 +44,14 @@ namespace Papercut.Network.SmtpCommands
 
             if (GetMatchCommands().IfNullEmpty().Any(c => c.Equals(command, StringComparison.OrdinalIgnoreCase)))
             {
-                Run(command, parts.Skip(1).ToArray());
+                if ((Session?.RequiresAuthentication ?? false) && 
+                    string.IsNullOrEmpty(Session?.Username) &&
+                    this.RequiresAuthentication)
+                {
+                    Connection.SendLine("530 Authentication is required").Wait();
+                }
+                else Run(command, parts.Skip(1).ToArray());
+                
                 return SmtpCommandResult.Done;
             }
 

--- a/src/Papercut.Network/SmtpCommands/EhloSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/EhloSmtpCommand.cs
@@ -8,6 +8,8 @@
 
     public class EhloSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "EHLO" };
@@ -20,6 +22,13 @@
             Connection.SendLine("250-{0}", NetworkHelper.GetLocalDnsHostName());
             Connection.SendLine("250-SMTPUTF8");
             Connection.SendLine("250-8BITMIME");
+
+            // NOTE: if implementing TLS/STARTTLS, we may wish to hide this capability until a TLS
+            // session is established.  I expect this would be along the lines of:
+            //
+            // if (Connection.RequiresTls && Connection.IsSecure) { ... }            
+            Connection.SendLine("250-AUTH LOGIN PLAIN");
+            
             Connection.SendLine("250 OK");
         }
     }

--- a/src/Papercut.Network/SmtpCommands/HeloSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/HeloSmtpCommand.cs
@@ -25,6 +25,8 @@ namespace Papercut.Network.SmtpCommands
 
     public class HeloSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "HELO" };

--- a/src/Papercut.Network/SmtpCommands/NoopSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/NoopSmtpCommand.cs
@@ -23,6 +23,8 @@ namespace Papercut.Network.SmtpCommands
 
     public class NoopSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "NOOP" };

--- a/src/Papercut.Network/SmtpCommands/QuitSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/QuitSmtpCommand.cs
@@ -23,6 +23,8 @@ namespace Papercut.Network.SmtpCommands
 
     public class QuitSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "QUIT" };

--- a/src/Papercut.Network/SmtpCommands/RsetSmtpCommand.cs
+++ b/src/Papercut.Network/SmtpCommands/RsetSmtpCommand.cs
@@ -23,6 +23,8 @@ namespace Papercut.Network.SmtpCommands
 
     public class RsetSmtpCommand : BaseSmtpCommand
     {
+        protected override bool RequiresAuthentication { get { return false; } }
+    
         protected override IEnumerable<string> GetMatchCommands()
         {
             return new[] { "RSET" };


### PR DESCRIPTION
I've had a stab at implementing basic SMTP authentication support.  It's not authentication against a specific source, yet (but I've indicated where that might be added), as I don't necessarily believe that real authentication is needed.

The initial use case that I have worked towards is to allow configuring the SMTP server component to require authentication, so as to prove that the SMTP client used by a developer was actually attempting to authenticate.  In the past, I've had some junior devs in my team who, when presented with an SMTP server like Papercut (which doesn't currently require any auth), *actually forget* that they still need to include the ability to configure SMTP authentication in their client apps!  By having Papercut able to *require* authentication (even if that authentication is arbitrary) I might avoid such happenings in the future.

However, it should also provide a reasonable starting point to perform *real* authentication, if so desired -- the `Authenticate` method in AuthSmtpCommand.cs could readily be extended to support a real authentication scheme (e.g. a persisted dictionary of username/password, or even an LDAP server), and I've made some implementation notes within the source.

At this stage, I am missing one aspect, which I'm hoping the regular maintainers can assist with -- actually defining and using an application setting to turn on/off the auth requirement on the server.  I have added a read/write `RequiresAuthentication` property to SmtpSession.cs which controls this, figuring that it can be set from an application setting in `SmtpProtocol.Begin`, but I can't follow how one defines an application setting, reads it and/or persists it through either UI's or Service's settings.

Thoughts/edits are welcome.