### PR TITLE
feat (WebUI) Set api endpoints to relative paths.

### DIFF
--- a/src/Papercut.Module.WebUI/assets/index.html
+++ b/src/Papercut.Module.WebUI/assets/index.html
@@ -153,7 +153,7 @@
 
   <div class="mail-content">
   <span class="download-raw pull-right">
-    <a ng-href="/api/messages/{{preview.Id}}/raw" target="_blank"><span class="glyphicon glyphicon-cloud-download"></span> Download raw message</a>
+    <a ng-href="api/messages/{{preview.Id}}/raw" target="_blank"><span class="glyphicon glyphicon-cloud-download"></span> Download raw message</a>
   </span>
       <ul class="nav nav-tabs">
         <li ng-if="hasHTML(preview)" ng-class="{ active: hasHTML(preview) }"><a href="#preview-html" data-toggle="tab">HTML</a></li>
@@ -183,7 +183,7 @@
                 <tr ng-repeat="section in preview.Sections">
                     <td>{{section.MediaType}}</td>
                     <td>{{section.FileName}}</td>
-                    <td><a title="Download and save section content" ng-href="/api/messages/{{preview.Id}}/sections/{{$index}}" target="_blank" class="glyphicon glyphicon-download-alt"></a></td>
+                    <td><a title="Download and save section content" ng-href="api/messages/{{preview.Id}}/sections/{{$index}}" target="_blank" class="glyphicon glyphicon-download-alt"></a></td>
                 </tr>
                 </tbody>
             </table>

--- a/src/Papercut.Module.WebUI/assets/js/controllers.js
+++ b/src/Papercut.Module.WebUI/assets/js/controllers.js
@@ -47,7 +47,7 @@ papercutApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout, $int
 
   $scope.refresh = function () {
       var e = startEvent("Loading messages", null, "glyphicon-download");
-      var url = '/api/messages'
+      var url = 'api/messages';
       if ($scope.startIndex > 0) {
           url += "?start=" + $scope.startIndex + "&limit=" + $scope.itemsPerPage;
       } else {
@@ -99,7 +99,7 @@ papercutApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout, $int
         return;
       }
 
-     $http.delete('/api/messages').finally(function () {
+     $http.delete('api/messages').finally(function () {
        $scope.refresh();
      });
   };
@@ -110,7 +110,7 @@ papercutApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout, $int
       } else {
           $scope.preview = message;
           var e = startEvent("Loading message", message.Id, "glyphicon-download-alt");
-          $http.get('/api/messages/' + message.Id).then(function (resp) {
+          $http.get('api/messages/' + message.Id).then(function (resp) {
               $scope.cache[message.Id] = resp.data;
 
               resp.data.previewHTML = $sce.trustAsHtml(resp.data.HtmlBody);
@@ -270,7 +270,7 @@ papercutApp.directive('bodyHtml', ['$sce', '$timeout', function ($sce, $timeout)
             }
 
             function replaceContentLinks(html, messageId) {
-                return html.replace(/cid:([^"^'^\s^;^,^//^/<^/>]+)/gi, '/api/messages/' + messageId + '/contents/$1');
+                return html.replace(/cid:([^"^'^\s^;^,^//^/<^/>]+)/gi, 'api/messages/' + messageId + '/contents/$1');
             }
         }
     };


### PR DESCRIPTION
Change the API endpoints in the WebUI to relative paths.  
This makes deployment behind reverse proxies easier to configure (the css/js were already relative).

