### PR TITLE
Message file name modifications.

### DIFF
--- a/src/Papercut.Core/Domain/Message/MessageEntry.cs
+++ b/src/Papercut.Core/Domain/Message/MessageEntry.cs
@@ -32,8 +32,8 @@ namespace Papercut.Core.Domain.Message
     public class MessageEntry : INotifyPropertyChanged, IEquatable<MessageEntry>, IFile
     {
         // You can start by using another timestamp format. An example below.
-        //public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
-        public const string DateTimeFormat = "yyyyMMddHHmmssFFF";
+        public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+        //public const string DateTimeFormat = "yyyyMMddHHmmssFFF";
 
 
         //static readonly Regex _nameFormat = new Regex(

--- a/src/Papercut.Core/Domain/Message/MessageEntry.cs
+++ b/src/Papercut.Core/Domain/Message/MessageEntry.cs
@@ -32,8 +32,11 @@ namespace Papercut.Core.Domain.Message
     public class MessageEntry : INotifyPropertyChanged, IEquatable<MessageEntry>, IFile
     {
         // You can start by using another timestamp format. An example below.
-        public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+        //public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+        // Bug. It is sucks to use FFF instead of fff.
+        // I.e. for 170ms we will get the string 17 and we will be forced to use RegEx dirty coding.
         //public const string DateTimeFormat = "yyyyMMddHHmmssFFF";
+        public const string DateTimeFormat = "yyyyMMddHHmmssfff";
 
 
         //static readonly Regex _nameFormat = new Regex(

--- a/src/Papercut.Core/Domain/Message/MessageEntry.cs
+++ b/src/Papercut.Core/Domain/Message/MessageEntry.cs
@@ -31,9 +31,12 @@ namespace Papercut.Core.Domain.Message
     /// </summary>
     public class MessageEntry : INotifyPropertyChanged, IEquatable<MessageEntry>, IFile
     {
-        static readonly Regex _nameFormat = new Regex(
-            @"^(?<date>\d{17})(\-[A-Z0-9]{6})?\.eml$",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+
+
+        //static readonly Regex _nameFormat = new Regex(
+        //    @"^(?<date>\d{17})(\-[A-Z0-9]{6})?\.eml$",
+        //    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         protected readonly FileInfo _info;
 
@@ -45,14 +48,20 @@ namespace Papercut.Core.Domain.Message
         {
             this._info = fileInfo;
 
-            Match match = _nameFormat.Match(this._info.Name);
-            if (match.Success)
-            {
-                this._created = DateTime.ParseExact(
-                    match.Groups["date"].Value,
-                    "yyyyMMddHHmmssFFF",
-                    CultureInfo.InvariantCulture);
-            }
+            //Match match = _nameFormat.Match(this._info.Name);
+            //if (match.Success)
+            //{
+            //    this._created = DateTime.ParseExact(
+            //        match.Groups["date"].Value,
+            //        "yyyyMMddHHmmssFFF",
+            //        CultureInfo.InvariantCulture);
+            //}
+
+            var dateTimePart = _info.Name.Substring(0, DateTimeFormat.Length);
+            _created = DateTime.ParseExact(
+                dateTimePart,
+                DateTimeFormat,
+                CultureInfo.InvariantCulture);
         }
 
         public MessageEntry(string file)

--- a/src/Papercut.Core/Domain/Message/MessageEntry.cs
+++ b/src/Papercut.Core/Domain/Message/MessageEntry.cs
@@ -31,7 +31,9 @@ namespace Papercut.Core.Domain.Message
     /// </summary>
     public class MessageEntry : INotifyPropertyChanged, IEquatable<MessageEntry>, IFile
     {
-        public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+        // You can start by using another timestamp format. An example below.
+        //public const string DateTimeFormat = "yy.MMdd-HH.mm.ssfff";
+        public const string DateTimeFormat = "yyyyMMddHHmmssFFF";
 
 
         //static readonly Regex _nameFormat = new Regex(

--- a/src/Papercut.Message/MessageRepository.cs
+++ b/src/Papercut.Message/MessageRepository.cs
@@ -98,7 +98,9 @@ namespace Papercut.Message
             return data;
         }
 
-        // it3xl.com: Loads all messages
+        /// <summary>
+        /// Loads all messages
+        /// </summary>
         public IList<MessageEntry> LoadMessages()
         {
             IEnumerable<string> files =

--- a/src/Papercut.Message/MessageRepository.cs
+++ b/src/Papercut.Message/MessageRepository.cs
@@ -21,7 +21,10 @@ namespace Papercut.Message
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Threading;
+
+    using MimeKit;
 
     using Papercut.Common.Extensions;
     using Papercut.Common.Helper;
@@ -95,6 +98,7 @@ namespace Papercut.Message
             return data;
         }
 
+        // it3xl.com: Loads all messages
         public IList<MessageEntry> LoadMessages()
         {
             IEnumerable<string> files =
@@ -108,15 +112,20 @@ namespace Papercut.Message
                     .ToList();
         }
 
-        public string SaveMessage(Action<FileStream> writeTo)
+        public string SaveMessage(string mailSubject, Action<FileStream> writeTo)
         {
             string fileName = null;
 
             try
             {
+                var cuttedPart = new string(mailSubject.Take(40).ToArray());
+                var validPart = MakeValidFileName(cuttedPart, "subject unknown");
+
+                var dateTimeFormatted = DateTime.Now.ToString(MessageEntry.DateTimeFormat);
+
                 // the file must not exists.  the resolution of DataTime.Now may be slow w.r.t. the speed of the received files
                 fileName = Path.Combine(_messagePathConfigurator.DefaultSavePath,
-                    $"{DateTime.Now:yyyyMMddHHmmssfff}-{StringHelpers.SmallRandomString()}.eml");
+                    $"{dateTimeFormatted} {validPart} {StringHelpers.SmallRandomString()}.eml");
 
                 using (var fileStream = File.Create(fileName))
                 {
@@ -131,6 +140,77 @@ namespace Papercut.Message
             }
 
             return fileName;
+        }
+
+        static char[] _invalidFileNameChars;
+        private const string EmptyStringReplacement = "_";
+
+        /// <summary>Replaces characters in <c>text</c> that are not allowed in 
+        /// file names with the specified replacement character.<para/>
+        /// https://stackoverflow.com/questions/620605/how-to-make-a-valid-windows-filename-from-an-arbitrary-string/25223884#25223884
+        /// </summary>
+        /// <param name="inputText">Text to make into a valid filename. The same string is returned if it is valid already.</param>
+        /// <param name="replacement">Replacement character, or null to simply remove bad characters.</param>
+        /// <param name="emptyText">A replacement for the empty result.</param>
+        /// <param name="fancy">Whether to replace quotes and slashes with the non-ASCII characters ” and ⁄.</param>
+        /// <returns>A string that can be used as a filename. If the output string would otherwise be empty,
+        /// returns <see cref="EmptyStringReplacement"/>.</returns>
+        public static string MakeValidFileName(string inputText, string emptyText = EmptyStringReplacement, char? replacement = '_', bool fancy = true)
+        {
+            var text = inputText ?? string.Empty;
+
+            var invalids = _invalidFileNameChars ?? (_invalidFileNameChars = Path.GetInvalidFileNameChars());
+
+            emptyText = emptyText ?? string.Empty;
+            if (!string.IsNullOrEmpty(emptyText) && emptyText != EmptyStringReplacement)
+            {
+                emptyText = MakeValidFileName(emptyText);
+            }
+
+            var sb = new StringBuilder(text.Length);
+            var changed = false;
+            foreach (var ch in text)
+            {
+                if (!invalids.Contains(ch))
+                {
+                    sb.Append(ch);
+
+                    continue;
+                }
+
+                changed = true;
+                var repl = replacement ?? '\0';
+                if (fancy)
+                {
+                    switch (ch)
+                    {
+                        case '"':
+                            // U+201D right double quotation mark
+                            repl = '”';
+                            break;
+                        case '\'':
+                            // U+2019 right single quotation mark
+                            repl = '’';
+                            break;
+                        case '/':
+                            // U+2044 fraction slash
+                            repl = '⁄';
+                            break;
+                    }
+                }
+
+                if (repl != '\0')
+                {
+                    sb.Append(repl);
+                }
+            }
+
+            if (sb.Length == 0)
+            {
+                return emptyText;
+            }
+
+            return changed ? sb.ToString() : text;
         }
     }
 }

--- a/src/Papercut.Message/ReceivedDataMessageHandler.cs
+++ b/src/Papercut.Message/ReceivedDataMessageHandler.cs
@@ -74,7 +74,7 @@ namespace Papercut.Message
                     }
                 }
 
-                file = _messageRepository.SaveMessage(fs => message.WriteTo(fs));
+                file = _messageRepository.SaveMessage(message.Subject, fs => message.WriteTo(fs));
             }
 
             try

--- a/test/Papercut.Module.WebUI.Tests/MessageFacts/LoadMessageFacts.cs
+++ b/test/Papercut.Module.WebUI.Tests/MessageFacts/LoadMessageFacts.cs
@@ -62,7 +62,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                 From = {new MailboxAddress("mffeng@gmail.com")}
             };
 
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
 
             var messages = Get<MessageListResponse>("/api/messages").Messages;
             Assert.AreEqual(1, messages.Count);
@@ -96,7 +96,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
             for (int i = 0; i < 10; i++)
             {
                 existedMail.Subject = $"Test {i+1}";
-                this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+                this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
                 Thread.Sleep(10);
             }
 
@@ -130,7 +130,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                 Bcc = {new MailboxAddress("rzhe@gmail.com"), new MailboxAddress("xueting@gmail.com")},
                 Body = new TextPart("plain") {Text = "Hello Buddy"}
             };
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
             var messages = Get<MessageListResponse>("/api/messages").Messages;
             var id = messages.First().Id;
 
@@ -171,7 +171,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
             };
             existedMail.Headers.Add(HeaderId.ReplyTo, "one@replyto.com");
             existedMail.Headers.Add("X-Extended", "extended value");
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
             var messages = Get<MessageListResponse>("/api/messages").Messages;
             var id = messages.First().Id;
 

--- a/test/Papercut.Module.WebUI.Tests/MessageFacts/MessageMetaFacts.cs
+++ b/test/Papercut.Module.WebUI.Tests/MessageFacts/MessageMetaFacts.cs
@@ -71,7 +71,9 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
 
             var disposition = response.Content.Headers.ContentDisposition;
             Assert.AreEqual(DispositionTypeNames.Attachment, disposition.DispositionType);
-            Assert.AreEqual(messageId, disposition.FileName);
+
+            var uriMessageId = Uri.EscapeDataString(messageId ?? string.Empty);
+            Assert.AreEqual(uriMessageId, disposition.FileName);
 
 
             MimeMessage downloadMessage;
@@ -107,7 +109,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                     }
                 });
 
-            return this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            return this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
         }
 
         class MessageListResponse

--- a/test/Papercut.Module.WebUI.Tests/MessageFacts/MessageSectionsFacts.cs
+++ b/test/Papercut.Module.WebUI.Tests/MessageFacts/MessageSectionsFacts.cs
@@ -60,7 +60,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                     }
                 }
             };
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
 
             var messageId = Get<MessageListResponse>("/api/messages").Messages.First().Id;
 
@@ -89,7 +89,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                     }
                 }
             };
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
 
             var messageId = Get<MessageListResponse>("/api/messages").Messages.First().Id;
 
@@ -119,7 +119,7 @@ namespace Papercut.Module.WebUI.Test.MessageFacts
                     }
                 }
             };
-            this._messageRepository.SaveMessage(fs => existedMail.WriteTo(fs));
+            this._messageRepository.SaveMessage(existedMail.Subject, fs => existedMail.WriteTo(fs));
 
             var messageId = Get<MessageListResponse>("/api/messages").Messages.First().Id;
 


### PR DESCRIPTION
Hi, please consider the following ideas to make the message file name more readable.

My pull request 

- adds a limited part of the mail subject to the massage file name;
- allows to change date-time format at the beginning of use of Papercut.


I don't know all subtlety of your code, of course.
At least I have made your tests working.
I didn't test it on my development environment yet.