### PR TITLE
Serialize socket messages to a single line of JSON

### DIFF
--- a/src/Papercut.Network/PapercutClient.cs
+++ b/src/Papercut.Network/PapercutClient.cs
@@ -19,7 +19,7 @@ namespace Papercut.Network
 {
     using System;
     using System.Net.Sockets;
-
+    using Newtonsoft.Json;
     using Papercut.Common.Domain;
     using Papercut.Common.Extensions;
     using Papercut.Core.Infrastructure.Json;
@@ -36,6 +36,14 @@ namespace Papercut.Network
         public const int ServerPort = 37403;
 
         readonly ILogger _logger;
+
+        readonly JsonSerializerSettings _singleLineJsonSettings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Auto,
+            Formatting = Formatting.None,
+            NullValueHandling = NullValueHandling.Include,
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple
+        };
 
         public PapercutClient(ILogger logger)
         {
@@ -167,7 +175,7 @@ namespace Papercut.Network
                     CommandType = protocolCommandType,
                     Type = @event.GetType(),
                     ByteSize = eventJson.Length
-                }.ToJson());
+                }.ToJson(_singleLineJsonSettings));
 
             response = stream.ReadString().Trim();
             if (response == "ACK") stream.WriteStr(eventJson);


### PR DESCRIPTION
Fixes #125.

When Papercut.Service reads messages from the socket, it expects an entire message to be on one line. Since the default serializer settings use indented formatting, the server tried to deserialize "{" and failed.

This prevents the UI from appearing until the server is restarted. The UI sends a message to the Papercut server when launched and doesn't display a window until it receives a reply or the socket closes. The server does neither of these.

This PR adds a dedicated JsonSerializerSettings to the PapercutClient so changes to the application's default formatting won't break the socket protocol.

I also considered changing the server so it closes the connection if a JsonSerializationException occurs. My thought was that if we can't parse a message, our parser is in an unknown state. But, since this protocol reads until a `\n`, I suppose the reader eventually recovers. Today was my first time working with this code, so I'm not yet sure if the preferred style is to abort on first error, or to muddle through as best we can.