### PR TITLE
Add adress, server and UI port in json configuration

### DIFF
--- a/src/Papercut.Infrastructure.IPComm/IPComm/PapercutIPCommClient.cs
+++ b/src/Papercut.Infrastructure.IPComm/IPComm/PapercutIPCommClient.cs
@@ -24,24 +24,20 @@ namespace Papercut.Infrastructure.IPComm.IPComm
 
     using Papercut.Common.Domain;
     using Papercut.Common.Extensions;
-
+    using Papercut.Core.Domain.Settings;
     using Serilog;
 
     public class PapercutIPCommClient : IDisposable
     {
-        public const string Localhost = "127.0.0.1";
-
-        public const int ClientPort = 37402;
-
-        public const int ServerPort = 37403;
 
         readonly ILogger _logger;
 
-        public PapercutIPCommClient(ILogger logger)
+        public PapercutIPCommClient(ISettingStore settingStore, 
+            ILogger logger)
         {
             this._logger = logger;
-            this.Host = Localhost;
-            this.Port = ClientPort;
+            this.Host = settingStore.GetOrSet("IPCommServerIPAddress", IPCommConstants.Localhost, $"The IP Comm Server IP address (Defaults to {IPCommConstants.Localhost}).");
+            this.Port = settingStore.GetOrSet("IPCommServerUIPort", IPCommConstants.UiListeningPort, $"The IP Comm Server UI listening port (Defaults to {IPCommConstants.UiListeningPort}).");
         }
 
         public string Host { get; set; }

--- a/src/Papercut.Service/Papercut.Service.Settings.json
+++ b/src/Papercut.Service/Papercut.Service.Settings.json
@@ -1,13 +1,22 @@
 ﻿{
-    "HttpPort_Description": "## The Http Web UI Server listening port (Defaults to 37408). Set to 0 to disable Http Web UI Server.",
-    "HttpPort": "37408",
+  "HttpPort_Description": "## The Http Web UI Server listening port (Defaults to 37408). Set to 0 to disable Http Web UI Server.",
+  "HttpPort": "37408",
 
-    "IP_Description": "## SMTP Server listening IP. 'Any' is the default and it means '0.0.0.0'.",
-    "IP": "Any",
+  "IP_Description": "## SMTP Server listening IP. 'Any' is the default and it means '0.0.0.0'.",
+  "IP": "Any",
 
-    "Port_Description": "## SMTP Server listening Port. Default is 25.",
-    "Port": "25",
+  "Port_Description": "## SMTP Server listening Port. Default is 25.",
+  "Port": "25",
 
-    "SeqEndpoint_Description": "## Populate with a endpoint if you want to enable SEQ (https://getseq.net/) logging.",
-    "SeqEndpoint": null
+  "SeqEndpoint_Description": "## Populate with a endpoint if you want to enable SEQ (https://getseq.net/) logging.",
+  "SeqEndpoint": null,
+
+  "IPCommServerIPAddress_Description": "## The IP Comm Server IP address (Defaults to 127.0.0.1).",
+  "IPCommServerIPAddress": "127.0.0.1",
+
+  "IPCommServerPort_Description": "## The IP Comm Server listening port (Defaults to 37403).",
+  "IPCommServerPort": "37405",
+
+  "IPCommServerUIPort_Description": "## The IP Comm Server listening port (Defaults to 37402).",
+  "IPCommServerUIPort": "37404"
 }

--- a/src/Papercut.Service/Services/PapercutServerService.cs
+++ b/src/Papercut.Service/Services/PapercutServerService.cs
@@ -96,8 +96,8 @@ namespace Papercut.Service.Services
                 new PapercutServicePreStartEvent { AppMeta = _applicationMetaData });
 
             this._ipCommServer.ObserveStartServer(
-                    IPCommConstants.Localhost,
-                    IPCommConstants.ServiceListeningPort,
+                    _ipCommServer.ListenIpAddress,
+                    _ipCommServer.ListenPort,
                 TaskPoolScheduler.Default)
                 .DelaySubscription(TimeSpan.FromSeconds(1)).Retry(5)
                 .Subscribe(
@@ -109,8 +109,8 @@ namespace Papercut.Service.Services
                     _logger.Warning(
                         e,
                         "Unable to Create Papercut IPComm Server Listener on {IP}:{Port}. After 5 Retries. Failing",
-                        IPCommConstants.Localhost,
-                        IPCommConstants.ServiceListeningPort),
+                        _ipCommServer.ListenIpAddress,
+                        _ipCommServer.ListenPort),
                     // on complete
                     () => { });
 

--- a/src/Papercut.Service/Services/PublishAppEventsHandlerToClientService.cs
+++ b/src/Papercut.Service/Services/PublishAppEventsHandlerToClientService.cs
@@ -60,31 +60,31 @@ namespace Papercut.Service.Services
         PapercutIPCommClient GetClient()
         {
             PapercutIPCommClient messenger = _papercutClientFactory();
-            messenger.Port = IPCommConstants.UiListeningPort;
             return messenger;
         }
 
         public void Publish<T>(T @event)
             where T : IEvent
         {
-            try
+            using (var ipCommClient = GetClient())
             {
-                _logger.Information(
-                    "Publishing {@" + @event.GetType().Name + "} to the Papercut Client",
-                    @event);
-
-                using (var ipCommClient = GetClient())
+                try
                 {
+                    _logger.Information(
+                        "Publishing {@" + @event.GetType().Name + "} to the Papercut Client",
+                        @event);
+
                     ipCommClient.PublishEventServer(@event);
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.Warning(
-                    ex,
-                    "Failed to publish {Address} {Port} specified. Papercut UI is most likely not running.",
-                    IPCommConstants.Localhost,
-                    IPCommConstants.UiListeningPort);
+
+                catch (Exception ex)
+                {
+                    _logger.Warning(
+                        ex,
+                        "Failed to publish {Address} {Port} specified. Papercut UI is most likely not running.",
+                        ipCommClient.Host,
+                        ipCommClient.Port);
+                }
             }
         }
     }

--- a/src/Papercut.UI/Services/PapercutClientServerCoordinator.cs
+++ b/src/Papercut.UI/Services/PapercutClientServerCoordinator.cs
@@ -52,8 +52,8 @@ namespace Papercut.Services
         public void Handle(PapercutClientReadyEvent @event)
         {
             this._papercutIPCommServer.ObserveStartServer(
-                    IPCommConstants.Localhost,
-                    IPCommConstants.UiListeningPort,
+                    _papercutIPCommServer.ListenIpAddress,
+                    _papercutIPCommServer.UIListenPort,
                     TaskPoolScheduler.Default)
                 .DelaySubscription(TimeSpan.FromMilliseconds(500)).Retry(5)
                 .Subscribe(
@@ -61,8 +61,8 @@ namespace Papercut.Services
                     ex => this._logger.Warning(
                         ex,
                         "Papercut IPComm Server failed to bind to the {Address} {Port} specified. The port may already be in use by another process.",
-                        IPCommConstants.Localhost,
-                        IPCommConstants.UiListeningPort),
+                        _papercutIPCommServer.ListenIpAddress,
+                        _papercutIPCommServer.UIListenPort),
                     () => { });
         }
     }

--- a/src/Papercut.UI/Services/PapercutServiceBackendCoordinator.cs
+++ b/src/Papercut.UI/Services/PapercutServiceBackendCoordinator.cs
@@ -204,7 +204,6 @@ namespace Papercut.Services
         PapercutIPCommClient GetClient()
         {
             PapercutIPCommClient messenger = _papercutClientFactory();
-            messenger.Port = IPCommConstants.ServiceListeningPort;
             return messenger;
         }
     }

--- a/src/Papercut.UI/Services/SingleInstanceService.cs
+++ b/src/Papercut.UI/Services/SingleInstanceService.cs
@@ -69,9 +69,7 @@ namespace Papercut.Services
 
             Logger.Debug(
                 "Second process run. Shutting this process down and pushing show event to other process");
-
-            this._papercutIPCommClient.Port = IPCommConstants.UiListeningPort;
-
+            
             // papercut is already running, push event to other UI process
             this._papercutIPCommClient.PublishEventServer(new ShowMainWindowEvent());
 


### PR DESCRIPTION
Signed-off-by: dadge <pinos.david@gmail.com>

Hello, 

I am working for ITER organization, a research porject to create the first thermonuclear fusion reactor.
For one of our project, we need several instances of Papercut working on one server. I've made the changes to make the ipcomm port configurable (not blocked at 37403). 

Regards, 